### PR TITLE
Fix various issues on macOS

### DIFF
--- a/IntelStack.xcodeproj/project.pbxproj
+++ b/IntelStack.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		84D068DE2ABDB4D900EC6E7E /* FileConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D068DC2ABDB4D900EC6E7E /* FileConstants.swift */; };
 		84D068E32ABEFDA000EC6E7E /* InternalPlugins.json in Resources */ = {isa = PBXBuildFile; fileRef = 84D068E22ABEFDA000EC6E7E /* InternalPlugins.json */; };
 		84D068E42ABEFDA000EC6E7E /* InternalPlugins.json in Resources */ = {isa = PBXBuildFile; fileRef = 84D068E22ABEFDA000EC6E7E /* InternalPlugins.json */; };
+		84D1F62E2B5A405200D260EB /* Bundle+BundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D1F62D2B5A405200D260EB /* Bundle+BundleExtension.swift */; platformFilters = (macos, ); };
+		84D1F62F2B5A405500D260EB /* Bundle+BundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D1F62D2B5A405200D260EB /* Bundle+BundleExtension.swift */; platformFilters = (macos, ); };
 		84D8E95B2AB7312C000234A9 /* ScriptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D8E95A2AB7312C000234A9 /* ScriptManager.swift */; };
 		84D8E95D2AB731AE000234A9 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D8E95C2AB731AE000234A9 /* Plugin.swift */; };
 		84D8E9612AB73CD9000234A9 /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D8E9602AB73CD9000234A9 /* FileManager.swift */; };
@@ -130,6 +132,7 @@
 		84D068D82ABDB2EB00EC6E7E /* ModelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelContainer.swift; sourceTree = "<group>"; };
 		84D068DC2ABDB4D900EC6E7E /* FileConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileConstants.swift; sourceTree = "<group>"; };
 		84D068E22ABEFDA000EC6E7E /* InternalPlugins.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = InternalPlugins.json; sourceTree = "<group>"; };
+		84D1F62D2B5A405200D260EB /* Bundle+BundleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+BundleExtension.swift"; sourceTree = "<group>"; };
 		84D8E95A2AB7312C000234A9 /* ScriptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptManager.swift; sourceTree = "<group>"; };
 		84D8E95C2AB731AE000234A9 /* Plugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plugin.swift; sourceTree = "<group>"; };
 		84D8E9602AB73CD9000234A9 /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
@@ -329,6 +332,22 @@
 			path = Data;
 			sourceTree = "<group>";
 		};
+		84D1F62B2B5A3FE200D260EB /* macOS */ = {
+			isa = PBXGroup;
+			children = (
+				84D1F62C2B5A3FF600D260EB /* Extensions */,
+			);
+			path = macOS;
+			sourceTree = "<group>";
+		};
+		84D1F62C2B5A3FF600D260EB /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				84D1F62D2B5A405200D260EB /* Bundle+BundleExtension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		84D8E9572AB7299A000234A9 /* Data */ = {
 			isa = PBXGroup;
 			children = (
@@ -346,6 +365,7 @@
 			children = (
 				84D8E9572AB7299A000234A9 /* Data */,
 				84D8E95F2AB73CAD000234A9 /* Extensions */,
+				84D1F62B2B5A3FE200D260EB /* macOS */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -520,6 +540,7 @@
 			files = (
 				84D8E9632AB73E04000234A9 /* Plugin.swift in Sources */,
 				84D8E96B2AB87859000234A9 /* UserScriptMetadata.swift in Sources */,
+				84D1F62F2B5A405500D260EB /* Bundle+BundleExtension.swift in Sources */,
 				84D8E9652AB73E0B000234A9 /* FileManager.swift in Sources */,
 				84D068DE2ABDB4D900EC6E7E /* FileConstants.swift in Sources */,
 				840F49B92AB70C3600012C44 /* SafariWebExtensionHandler.swift in Sources */,
@@ -546,6 +567,7 @@
 				840F49D52AB7101F00012C44 /* SettingsView.swift in Sources */,
 				84D068DD2ABDB4D900EC6E7E /* FileConstants.swift in Sources */,
 				843FCB2F2AB9C0FA00C93D1E /* ScriptManager+Task.swift in Sources */,
+				84D1F62E2B5A405200D260EB /* Bundle+BundleExtension.swift in Sources */,
 				840F49D72AB7108200012C44 /* PluginListView.swift in Sources */,
 				84D8E95B2AB7312C000234A9 /* ScriptManager.swift in Sources */,
 				842FFA4C2B57A1F4006DF29F /* UserScriptMetadataDecoder.swift in Sources */,

--- a/IntelStack.xcodeproj/project.pbxproj
+++ b/IntelStack.xcodeproj/project.pbxproj
@@ -611,6 +611,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -648,6 +649,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"-framework",

--- a/Shared/Data/ScriptManager+ExternalScripts.swift
+++ b/Shared/Data/ScriptManager+ExternalScripts.swift
@@ -55,16 +55,16 @@ extension ScriptManager {
     
     @discardableResult
     static func sync(with context: ModelContext = .init(.default)) throws -> URL? {
-        guard
-            let externalURL = UserDefaults.shared.externalScriptsBookmarkURL,
-            externalURL.startAccessingSecurityScopedResource()
-        else {
+        guard let externalURL = UserDefaults.shared.externalScriptsBookmarkURL else {
             try context.delete(model: Plugin.self, where: Plugin.externalPredicate)
             return nil
         }
         
+        let isAccessingSecurityScopedResource = externalURL.startAccessingSecurityScopedResource()
         defer {
-            externalURL.stopAccessingSecurityScopedResource()
+            if isAccessingSecurityScopedResource {
+                externalURL.stopAccessingSecurityScopedResource()
+            }
         }
         try sync(in: externalURL, with: context)
         

--- a/Shared/Extensions/URL.swift
+++ b/Shared/Extensions/URL.swift
@@ -9,15 +9,15 @@ import Foundation
 
 extension URL {
     init(resolvingSecurityScopedBookmarkData data: Data, bookmarkDataIsStale: inout Bool) throws {
-        #if os(macOS)
+#if os(macOS)
         try self.init(
             resolvingBookmarkData: data,
             options: .withSecurityScope,
             bookmarkDataIsStale: &bookmarkDataIsStale
         )
-        #else
+#else
         try self.init(resolvingBookmarkData: data, bookmarkDataIsStale: &bookmarkDataIsStale)
-        #endif
+#endif
     }
     
     init(resolvingSecurityScopedBookmarkData data: Data) throws {

--- a/Shared/Extensions/UserDefaults+Bookmark.swift
+++ b/Shared/Extensions/UserDefaults+Bookmark.swift
@@ -8,15 +8,49 @@
 import Foundation
 
 extension UserDefaults {
+    // A solution from quoid/userscripts/xcode/Shared/Preferences.swift
+    // For macOS, the security-scoped bookmark (created with .withSecurityScope option) is resolvable only in the main
+    // app, but not in the app extension, but a non-security-scoped bookmark (or called implicity security scope) is
+    // resolvable and accessable in the app extension (really weird).
+#if os(macOS)
+    fileprivate static let implicitySecurityScopeBookmarkKeySuffix = ".ImplicitySecurityScope"
+#endif
+
     func bookmark(forKey defaultName: String) -> URL? {
-        guard let bookmarkData = data(forKey: defaultName) else {
-            return nil
+        let bookmarkData: Data?
+#if os(macOS)
+        if Bundle.main.isAppExtension {
+            bookmarkData = data(forKey: defaultName + Self.implicitySecurityScopeBookmarkKeySuffix)
+        } else {
+            bookmarkData = data(forKey: defaultName)
         }
-        var bookmarkDataIsStale = true
-        let url = try? URL(resolvingSecurityScopedBookmarkData: bookmarkData, bookmarkDataIsStale: &bookmarkDataIsStale)
-        if bookmarkDataIsStale {
+#else
+        bookmarkData = data(forKey: defaultName)
+#endif
+        guard let bookmarkData else { return nil }
+        
+        var bookmarkDataIsStale = false
+        let url: URL?
+#if os(macOS)
+        if Bundle.main.isAppExtension {
+            url = try? .init(resolvingBookmarkData: bookmarkData, bookmarkDataIsStale: &bookmarkDataIsStale)
+            // Prevent updating bookmark in app extension
+            bookmarkDataIsStale = false
+        } else {
+            url = try? .init(
+                resolvingSecurityScopedBookmarkData: bookmarkData, bookmarkDataIsStale: &bookmarkDataIsStale
+            )
+        }
+#else
+        url = try? .init(
+            resolvingSecurityScopedBookmarkData: bookmarkData, bookmarkDataIsStale: &bookmarkDataIsStale
+        )
+#endif
+        if bookmarkDataIsStale, let url, url.startAccessingSecurityScopedResource() {
             setBookmark(url, forKey: defaultName)
+            url.stopAccessingSecurityScopedResource()
         }
+        
         return url
     }
     
@@ -26,11 +60,17 @@ extension UserDefaults {
             set(value, forKey: defaultName)
             return
         }
-        #if os(macOS)
-        guard let bookmark = try? url.bookmarkData(options: .withSecurityScope) else { return }
-        #else
+#if os(macOS)
+        guard
+            let bookmark = try? url.bookmarkData(options: .withSecurityScope),
+            let implicitySecurityScopeBookmark = try? url.bookmarkData()
+        else {
+            return
+        }
+        set(implicitySecurityScopeBookmark, forKey: defaultName + Self.implicitySecurityScopeBookmarkKeySuffix)
+#else
         guard let bookmark = try? url.bookmarkData() else { return }
-        #endif
+#endif
         set(bookmark, forKey: defaultName)
         return
     }

--- a/Shared/macOS/Extensions/Bundle+BundleExtension.swift
+++ b/Shared/macOS/Extensions/Bundle+BundleExtension.swift
@@ -1,0 +1,15 @@
+//
+//  Bundle+BundleExtension.swift
+//  Intel Stack
+//
+//  Created by Lucka on 2024-01-19.
+//
+
+import Foundation
+
+extension Bundle {
+    // Maybe a bad idea
+    var isAppExtension: Bool {
+        bundlePath.hasSuffix(".appex")
+    }
+}

--- a/Web Extension/Shared/SafariWebExtensionHandler+Methods.swift
+++ b/Web Extension/Shared/SafariWebExtensionHandler+Methods.swift
@@ -33,16 +33,16 @@ extension SafariWebExtensionHandler {
         var scripts = [ CodeWrapper.wrap(code: mainScriptContent, metadata: mainScriptMetadata) ]
         
         let externalURL: URL?
-        let accessingSecurityScopedResource: Bool
+        let isAccessingSecurityScopedResource: Bool
         if plugins.contains(where: { !$0.isInternal }) {
             externalURL = UserDefaults.shared.externalScriptsBookmarkURL
-            accessingSecurityScopedResource = externalURL?.startAccessingSecurityScopedResource() ?? false
+            isAccessingSecurityScopedResource = externalURL?.startAccessingSecurityScopedResource() ?? false
         } else {
             externalURL = nil
-            accessingSecurityScopedResource = false
+            isAccessingSecurityScopedResource = false
         }
         defer {
-            if let externalURL, accessingSecurityScopedResource {
+            if let externalURL, isAccessingSecurityScopedResource {
                 externalURL.stopAccessingSecurityScopedResource()
             }
         }


### PR DESCRIPTION
## Fixed
- Running the web extension (opening Intel Map or the popup) may cause external location being reset and all external plugins being remove from database
- The minimum target version of web extension is not 14.0