### PR TITLE
Fix typo in data model

### DIFF
--- a/Shared/Data/Plugin.swift
+++ b/Shared/Data/Plugin.swift
@@ -13,7 +13,8 @@ import SwiftData
 class Plugin {
     var uuid: UUID
     
-    var idendifier: String
+    @Attribute(originalName: "idendifier")  // A typo, consider to remove in future version
+    var identifier: String
     
     var enabled: Bool = false
     
@@ -31,14 +32,14 @@ class Plugin {
     
     init(
         uuid: UUID = .init(),
-        idendifier: String,
+        identifier: String,
         name: String,
         category: Category,
         isInternal: Bool,
         filename: String
     ) {
         self.uuid = uuid
-        self.idendifier = idendifier
+        self.identifier = identifier
         self.name = name
         self.categoryValue = category.rawValue
         self.isInternal = isInternal

--- a/Shared/Data/PluginMetadata.swift
+++ b/Shared/Data/PluginMetadata.swift
@@ -22,7 +22,7 @@ struct PluginMetadata : Decodable {
 extension Plugin {
     convenience init(metadata: PluginMetadata, isInternal: Bool, filename: String) {
         self.init(
-            idendifier: metadata.id,
+            identifier: metadata.id,
             name: metadata.name,
             category: metadata.category,
             isInternal: isInternal,
@@ -41,7 +41,7 @@ extension Plugin {
     }
     
     func update(from metadata: PluginMetadata) {
-        self.idendifier = metadata.id
+        self.identifier = metadata.id
         self.category = metadata.category
         self.author = metadata.author
         self.scriptDescription = metadata.description

--- a/Shared/Data/ScriptManager+ExternalScripts.swift
+++ b/Shared/Data/ScriptManager+ExternalScripts.swift
@@ -35,7 +35,7 @@ extension ScriptManager {
             }
         let plugins = try context.fetch(.init(predicate: Plugin.externalPredicate))
         for plugin in plugins {
-            guard let value = metadatas.removeValue(forKey: plugin.idendifier) else {
+            guard let value = metadatas.removeValue(forKey: plugin.identifier) else {
                 context.delete(plugin)
                 continue
             }


### PR DESCRIPTION
## Changed
- Rename `Plugin.idendifier` to `Plugin.identifier`
- Set the `originalName` to make lightweight migration

This change should be merged before next release, but not immediately.