### PR TITLE
Present errors in Safari popup and Intel webpage

### DIFF
--- a/IntelStack.xcodeproj/project.pbxproj
+++ b/IntelStack.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		8475D1932AD8333800D71F59 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 8475D1922AD8333800D71F59 /* Localizable.xcstrings */; };
 		8475D1962ADAD19100D71F59 /* images in Resources */ = {isa = PBXBuildFile; fileRef = 8475D1952ADAD19100D71F59 /* images */; };
 		84A917EF2B58EDCF009D53E8 /* UserScriptMetadataDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A917EE2B58EDCF009D53E8 /* UserScriptMetadataDecoderTests.swift */; };
+		84BD9FAF2BCA1CA100771DEA /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 8475D1922AD8333800D71F59 /* Localizable.xcstrings */; };
 		84D068D92ABDB2EB00EC6E7E /* ModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D068D82ABDB2EB00EC6E7E /* ModelContainer.swift */; };
 		84D068DA2ABDB2EB00EC6E7E /* ModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D068D82ABDB2EB00EC6E7E /* ModelContainer.swift */; };
 		84D068DD2ABDB4D900EC6E7E /* FileConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D068DC2ABDB4D900EC6E7E /* FileConstants.swift */; };
@@ -218,7 +219,6 @@
 				842318892AB7053A000A0A09 /* Assets.xcassets */,
 				84D068DB2ABDB44000EC6E7E /* Data */,
 				84D8E96C2AB87DE8000234A9 /* Extensions */,
-				8475D1912AD832EF00D71F59 /* Localization */,
 				840F49AF2AB7073A00012C44 /* Views */,
 			);
 			path = Shared;
@@ -408,6 +408,7 @@
 			children = (
 				84D8E9572AB7299A000234A9 /* Data */,
 				84D8E95F2AB73CAD000234A9 /* Extensions */,
+				8475D1912AD832EF00D71F59 /* Localization */,
 				84D1F62B2B5A3FE200D260EB /* macOS */,
 			);
 			path = Shared;
@@ -562,6 +563,7 @@
 				840F49BC2AB70C3600012C44 /* _locales in Resources */,
 				8475D1962ADAD19100D71F59 /* images in Resources */,
 				842F9D0A2ACE5A35002E750B /* popup in Resources */,
+				84BD9FAF2BCA1CA100771DEA /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Shared/Data/ScriptManager+ExternalScripts.swift
+++ b/Shared/Data/ScriptManager+ExternalScripts.swift
@@ -49,6 +49,7 @@ extension ScriptManager {
         try context.save()
     }
     
+    @discardableResult
     static func sync(with context: ModelContext = .init(.default)) throws -> URL? {
         guard let externalURL = UserDefaults.shared.externalScriptsBookmarkURL else {
             try context.delete(model: Plugin.self, where: Plugin.externalPredicate)

--- a/Shared/Localization/Localizable.xcstrings
+++ b/Shared/Localization/Localizable.xcstrings
@@ -977,6 +977,118 @@
         }
       }
     },
+    "SafariWebExtensionHandler.Error.MainScriptNotExists" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IITC main script does not exists, please open the Intel Stack app, follow the instruction to download main script and internal plugins."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IITC主脚本不存在，请打开Intel Stack应用，跟随介绍下载主脚本和内部插件。"
+          }
+        }
+      }
+    },
+    "SafariWebExtensionHandler.Error.NoMessage" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No message in the request."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请求中没有消息。"
+          }
+        }
+      }
+    },
+    "SafariWebExtensionHandler.Error.PluginNotFound" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "It seems the plugin does not exists."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这个插件似乎不存在。"
+          }
+        }
+      }
+    },
+    "SafariWebExtensionHandler.Error.RequestContentMissing %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"%@\" is missing in the request."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请求中缺少“%@”。"
+          }
+        }
+      }
+    },
+    "SafariWebExtensionHandler.Error.UnableToLoadPlugin %@ %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to load the plugin %1$@: %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法加载插件“%1$@”：%2$@"
+          }
+        }
+      }
+    },
+    "SafariWebExtensionHandler.Error.UnknownMethod %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Method of the request is unknown: %@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请求的方法未知：%@。"
+          }
+        }
+      }
+    },
+    "SafariWebExtensionHandler.NoPlugin" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No plugin exists, please open the Intel Stack app, follow the instruction to download main script and internal plugins."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有插件，请打开Intel Stack应用，跟随介绍下载主脚本和内部插件。"
+          }
+        }
+      }
+    },
     "SettingsView.About.IITCWebsite" : {
       "localizations" : {
         "en" : {

--- a/Web Extension/Shared/Resources/_locales/en/messages.json
+++ b/Web Extension/Shared/Resources/_locales/en/messages.json
@@ -5,7 +5,13 @@
     "extension_description": {
         "message": "Manage IITC script and plugin"
     },
+    "popup_alert_cancel": {
+        "message": "OK"
+    },
     "popup_scripts_enabled": {
         "message": "Enabled"
+    },
+    "error_invalid_response": {
+        "message": "The response is unavailable."
     }
 }

--- a/Web Extension/Shared/Resources/_locales/zh/messages.json
+++ b/Web Extension/Shared/Resources/_locales/zh/messages.json
@@ -5,7 +5,13 @@
     "extension_description": {
         "message": "管理IITC脚本和插件"
     },
+    "popup_alert_cancel": {
+        "message": "OK"
+    },
     "popup_scripts_enabled": {
         "message": "启用"
+    },
+    "error_invalid_response": {
+        "message": "响应不可用。"
     }
 }

--- a/Web Extension/Shared/Resources/content/main.js
+++ b/Web Extension/Shared/Resources/content/main.js
@@ -1,9 +1,15 @@
 async function execute() {
     const response = await browser.runtime.sendMessage({ method: "getInjectionData" });
-    if (!response || !response.scripts) {
-        console.error(`Invalid response: ${response}`);
+    if (!response) {
+        alert(browser.i18n.getMessage("error_invalid_response"));
         return;
     }
+
+    if (response.error) {
+        alert(response.error);
+        return;
+    }
+
     if (response.scripts.length === 0) {
         return;
     }
@@ -19,6 +25,10 @@ async function execute() {
         const node = document.createElement("script");
         node.textContent = script;
         document.head.appendChild(node);
+    }
+
+    if (response.warnings) {
+        alert(response.warnings.join("\n"));
     }
 }
 

--- a/Web Extension/Shared/Resources/popup/popup.css
+++ b/Web Extension/Shared/Resources/popup/popup.css
@@ -26,6 +26,37 @@ main {
     scroll-behavior: smooth;
 }
 
+main.error {
+    color: gray;
+    justify-content: center;
+    text-align: center;
+}
+
+dialog {
+    border: none;
+    border-radius: 0.6em;
+    padding: 0;
+}
+
+dialog > p {
+    margin: 0;
+    padding: 1.2em;
+    text-align: center;
+}
+
+dialog > form > button {
+    background: none;
+    border: none;
+    border-top: solid 1px gray;
+    padding: 0.6em;
+    width: 100%;
+}
+
+dialog::backdrop {
+    background-color: gray;
+    opacity: 0.5;
+}
+
 section {
     display: flex;
     flex-flow: column nowrap;

--- a/Web Extension/Shared/SafariWebExtensionHandler.swift
+++ b/Web Extension/Shared/SafariWebExtensionHandler.swift
@@ -18,10 +18,16 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         
         guard
             let requestItem = context.inputItems.first as? NSExtensionItem,
-            let message = requestItem.userInfo?[SFExtensionMessageKey] as? [ String : Any ],
-            let method = message["method"] as? String
+            let message = requestItem.userInfo?[SFExtensionMessageKey] as? [ String : Any ]
         else {
-            responseContent = [ "error" : "Unable to parse the request" ]
+            responseContent = [ "error" : String(localized: "SafariWebExtensionHandler.Error.NoMessage") ]
+            return
+        }
+        
+        guard let method = message["method"] as? String else {
+            responseContent = [
+                "error" : String(localized: "SafariWebExtensionHandler.Error.RequestContentMissing \("method")")
+            ]
             return
         }
         let arguments = message["arguments"] as? [ String : Any ]
@@ -33,19 +39,25 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
             responseContent = getPopupContentData()
         case "setPluginEnabled":
             guard let arguments else {
-                responseContent = [ "error" : "[arguments] is missing" ]
+                responseContent = [
+                    "error" : String(localized: "SafariWebExtensionHandler.Error.RequestContentMissing \("arguments")")
+                ]
                 break
             }
             responseContent = setPluginEnabled(with: arguments)
         case "setScriptsEnabled":
             guard let enable = arguments?["enable"] as? Bool else {
-                responseContent = [ "error" : "[arguments][enable] is missing" ]
+                responseContent = [
+                    "error" : String(localized: "SafariWebExtensionHandler.Error.RequestContentMissing \("arguments.enable")")
+                ]
                 break
             }
             UserDefaults.shared.scriptsEnabled = enable
             responseContent = [ "succeed" : true ]
         default:
-            responseContent = [ "error" : "Unknown method: \(method)" ]
+            responseContent = [
+                "error" : String(localized: "SafariWebExtensionHandler.Error.UnknownMethod \(method)")
+            ]
         }
     }
 }


### PR DESCRIPTION
## Added
- Display description on popup if any error occurs when open it, which might be very critical
- Present description with alert on popup and Intel webpage if any error occurs during the entire Intel Stack workflow