### PR TITLE
Fix "The response is unavailable" error for iOS/iPadOS 17.5

### DIFF
--- a/IntelStack.xcodeproj/project.pbxproj
+++ b/IntelStack.xcodeproj/project.pbxproj
@@ -908,7 +908,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.lucka.IntelStack;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -953,7 +953,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.lucka.IntelStack;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;

--- a/Shared/Localization/Localizable.xcstrings
+++ b/Shared/Localization/Localizable.xcstrings
@@ -1089,6 +1089,22 @@
         }
       }
     },
+    "SettingsView.About.Footer %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Made by [Lucka](https://t.me/SeeleUN) with %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Made by [Lucka](https://t.me/SeeleUN) with %@"
+          }
+        }
+      }
+    },
     "SettingsView.About.IITCWebsite" : {
       "localizations" : {
         "en" : {

--- a/Web Extension/Shared/Resources/background.js
+++ b/Web Extension/Shared/Resources/background.js
@@ -1,7 +1,5 @@
-async function forwardMessage(request, sender, sendResponse) {
-    const response = await browser.runtime.sendNativeMessage(request);
-    sendResponse(response);
-    return true;
+function forwardMessage(request, sender, sendResponse) {
+    return browser.runtime.sendNativeMessage(request);
 }
 
 browser.runtime.onMessage.addListener(forwardMessage);


### PR DESCRIPTION
## Fixed
- The Intel web page and Intel Stack browser popup always report "The response is unavailable" on iOS/iPadOS 17.5
- One localization is missing on Settings page