### PR TITLE
Apply a workaround for the "Invalid Response" issue

### DIFF
--- a/Web Extension/Shared/Resources/_locales/en/messages.json
+++ b/Web Extension/Shared/Resources/_locales/en/messages.json
@@ -12,6 +12,6 @@
         "message": "Enabled"
     },
     "error_invalid_response": {
-        "message": "The response is unavailable."
+        "message": "The response is unavailable. Please try to disable & re-enable the Intel Stack extension from Safari settings."
     }
 }

--- a/Web Extension/Shared/Resources/_locales/zh/messages.json
+++ b/Web Extension/Shared/Resources/_locales/zh/messages.json
@@ -12,6 +12,6 @@
         "message": "启用"
     },
     "error_invalid_response": {
-        "message": "响应不可用。"
+        "message": "响应不可用。请尝试在 Safari 设置中关闭并重新打开Intel Stack浏览器扩展。"
     }
 }

--- a/Web Extension/Shared/Resources/manifest.json
+++ b/Web Extension/Shared/Resources/manifest.json
@@ -11,7 +11,10 @@
     },
 
     "background": {
-        "service_worker": "background.js"
+        "scripts": [
+            "background.js"
+        ],
+        "persistent": false
     },
 
     "content_scripts": [{


### PR DESCRIPTION
[Seems like](https://developer.apple.com/forums/thread/721222) a bug of Safari, which shuts background service workers down once RAM usage reaches 80%, and not re-launches it at all. Background scripts don't seem to be affected, so we declared the `background.js` as a background script rather than a service worker.